### PR TITLE
Fix upper range values for goldenRatioTest.

### DIFF
--- a/code/tests.js
+++ b/code/tests.js
@@ -19,8 +19,8 @@ var tests = {
         assert.isTrue(code.isPrime(97), "IsPrime(97) should be true.");
     },
     goldenRatioTest: function() {
-        assert.isInRange(1.61800, 1,61806, code.goldenRatio(1.0, 1.0));
-        assert.isInRange(1.61800, 1,61806, code.goldenRatio(100, 6));
+        assert.isInRange(1.61800, 1.61806, code.goldenRatio(1.0, 1.0));
+        assert.isInRange(1.61800, 1.61806, code.goldenRatio(100, 6));
     },
     fibonacciTest: function() {
         assert.areEqual(0, code.fibonacci(0));


### PR DESCRIPTION
Tests fail for an implementation that appears to produce a correct value (1.6180555...). Inspecting `tests.js`, it looks like the upper range value in both assert.isInRange calls in `goldenRatioTest` is not a valid double in en-us (`1,61806`). Should it be (`1.61806`) instead?